### PR TITLE
Fix Spotify/listening status breaking command

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ module.exports = class ShowSessions extends Plugin {
 													)}](${activity.url})`;
 												case 2:
 													return `${formatWithoutReact(
-														MESSAGES.LISTENING_TO,
+														Messages.LISTENING_TO,
 														{ name: activity.state }
 													)}`;
 												case 3:


### PR DESCRIPTION
Fixes the following error when running the `sessions` command while listening to Spotify:
```
VM1081 C:\Tools\Essentials\Powercord\src\Powercord\plugins\pc-commands\monkeypatchMessages.js:28 An error occurred while executing command sessions: ReferenceError: MESSAGES is not defined
    at C:\Tools\Essentials\Powercord\src\Powercord\plugins\show-sessions\index.js:157:15
    at C:\Tools\Essentials\Powercord\src\Powercord\plugins\show-sessions\index.js:119:12
    at Array.map (<anonymous>)
    at ShowSessions.command (C:\Tools\Essentials\Powercord\src\Powercord\plugins\show-sessions\index.js:98:7)
    at Object.messages.sendMessage.oldSendMessage [as sendMessage] (C:\Tools\Essentials\Powercord\src\Powercord\plugins\pc-commands\monkeypatchMessages.js:25:30)
```

Thanks,
Elliott